### PR TITLE
Add link to DESCRIPTION + avoid mentioning `usethis::browse_github_pat()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
 Suggests:
     knitr,
     rmarkdown
-URL: URL: https://github.com/vnijs/gitgadget
+URL: https://vnijs.github.io/gitgadget/, https://github.com/vnijs/gitgadget
 BugReports: https://github.com/vnijs/gitgadget/issues
 License: GPL-3
 RoxygenNote: 7.2.3

--- a/inst/app/components/intro.R
+++ b/inst/app/components/intro.R
@@ -3,7 +3,7 @@
 # })
 
 # observeEvent(input$intro_token_gh_get, {
-#   ## based on usethis::browse_github_pat
+#   ## based on usethis::create_github_token
 #   utils::browseURL("https://github.com/settings/tokens/new?scopes=repo,gist&description=R:GITHUB_PAT")
 # })
 


### PR DESCRIPTION
For discoverability https://blog.r-hub.io/2019/12/10/urls/ (I still think this is worth doing, just clearing stale PRs)

`browse_github_pat()` is deprecated in usethis 2.0.0 in favour of `create_github_token()`.
